### PR TITLE
Fix #12: add missing #include <algorithm>

### DIFF
--- a/src/chromobius/datatypes/atomic_error.test.cc
+++ b/src/chromobius/datatypes/atomic_error.test.cc
@@ -15,6 +15,7 @@
 #include "chromobius/datatypes/atomic_error.h"
 
 #include <random>
+#include <algorithm>
 
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
Resolves issue #12: error about "sort is not a member of std".

Presumably including algorithms was not needed in the past, and I don't know what version change in the toolchain (gcc perhaps?) resulted in this being needed now.