### PR TITLE
Fix issue #15: update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: ci
+name: Continuous integration
+
 on:
   push:
     branches:
@@ -25,6 +26,16 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      bazel_version:
+        description: Version of Bazel to use
+        type: string
+
+env:
+  # Default Bazel version to use.
+  bazel_version: '6.5.0'
+
 jobs:
   build_dist:
     runs-on: ${{ matrix.os_dist.os }}
@@ -109,7 +120,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: bazel-contrib/setup-bazel@0.12.1
       env:
-        USE_BAZEL_VERSION: 6.5.0
+        USE_BAZEL_VERSION: ${{inputs.bazel_version || env.bazel_version}}
       with:
         bazelisk-cache: true
         disk-cache: ${{ github.workflow }}
@@ -177,7 +188,7 @@ jobs:
       - uses: actions/setup-python@v5
       - uses: bazel-contrib/setup-bazel@0.12.1
         env:
-          USE_BAZEL_VERSION: 6.5.0
+          USE_BAZEL_VERSION: ${{inputs.bazel_version || env.bazel_version}}
         with:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
@@ -204,7 +215,7 @@ jobs:
       - uses: actions/setup-python@v5
       - uses: bazel-contrib/setup-bazel@0.12.1
         env:
-          USE_BAZEL_VERSION: 6.5.0
+          USE_BAZEL_VERSION: ${{inputs.bazel_version || env.bazel_version}}
         with:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Continuous integration
+name: ci
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,10 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      bazel_version:
-        description: Version of Bazel to use
-        type: string
 
 env:
-  # Default Bazel version to use.
-  bazel_version: '6.5.0'
+  # C.f. https://github.com/bazelbuild/bazelisk#readme
+  USE_BAZEL_VERSION: '6.5.0'
 
 jobs:
   build_dist:
@@ -119,8 +115,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: bazel-contrib/setup-bazel@0.12.1
-      env:
-        USE_BAZEL_VERSION: ${{inputs.bazel_version || env.bazel_version}}
       with:
         bazelisk-cache: true
         disk-cache: ${{ github.workflow }}
@@ -187,8 +181,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - uses: bazel-contrib/setup-bazel@0.12.1
-        env:
-          USE_BAZEL_VERSION: ${{inputs.bazel_version || env.bazel_version}}
         with:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
@@ -214,8 +206,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - uses: bazel-contrib/setup-bazel@0.12.1
-        env:
-          USE_BAZEL_VERSION: ${{inputs.bazel_version || env.bazel_version}}
         with:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
       CIBW_TEST_REQUIRES: pytest stim~=1.14 sinter pygltflib
       CIBW_TEST_COMMAND: pytest {project}/src
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - run: python tools/overwrite_dev_versions_with_date.py
       - run: python -m pip install pybind11~=2.11.1 cibuildwheel~=2.16.2 setuptools
       - run: python -m cibuildwheel --print-build-identifiers
@@ -69,8 +69,8 @@ jobs:
   build_sdist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - run: python -m pip install setuptools pybind11~=2.11.1
       - run: python tools/overwrite_dev_versions_with_date.py
       - run: mkdir output
@@ -91,22 +91,22 @@ jobs:
   check_sdist_installs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - run: python -m pip install pybind11~=2.11.1 cibuildwheel~=2.16.2 setuptools
       - run: python setup.py sdist
       - run: pip install dist/*.tar.gz
   run_main:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - run: cmake .
     - run: make chromobius -j 2
     - run: out/chromobius --help
   build_bazel:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: bazel-contrib/setup-bazel@0.12.1
       env:
         USE_BAZEL_VERSION: 6.5.0
@@ -120,7 +120,7 @@ jobs:
   build_clang:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: |
         cd ..
         git clone https://github.com/google/googletest.git -b release-1.12.1
@@ -138,14 +138,14 @@ jobs:
   perf:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: cmake .
     - run: make chromobius_perf -j 2
     - run: out/chromobius_perf
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: |
         cd ..
         git clone https://github.com/google/googletest.git -b release-1.12.1
@@ -159,7 +159,7 @@ jobs:
   test_o3:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: |
         cd ..
         git clone https://github.com/google/googletest.git -b release-1.12.1
@@ -173,9 +173,9 @@ jobs:
   test_generated_docs_are_fresh:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - uses: bazel-contrib/setup-bazel@0.8.5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - uses: bazel-contrib/setup-bazel@0.12.1
         env:
           USE_BAZEL_VERSION: 6.5.0
         with:
@@ -191,7 +191,7 @@ jobs:
   test_generated_file_lists_are_fresh:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: tools/regen_file_lists.sh /tmp
       - run: diff /tmp/perf_files file_lists/perf_files
       - run: diff /tmp/pybind_files file_lists/pybind_files
@@ -200,9 +200,9 @@ jobs:
   test_pybind:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - uses: bazel-contrib/setup-bazel@0.8.5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - uses: bazel-contrib/setup-bazel@0.12.1
         env:
           USE_BAZEL_VERSION: 6.5.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: bazel-contrib/setup-bazel@0.8.5
+    - uses: bazel-contrib/setup-bazel@0.12.1
+      env:
+        USE_BAZEL_VERSION: 6.5.0
       with:
         bazelisk-cache: true
         disk-cache: ${{ github.workflow }}
@@ -116,7 +118,7 @@ jobs:
     - run: bazel build :all
     - run: bazel test :chromobius_test
   build_clang:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - run: |
@@ -174,6 +176,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
       - uses: bazel-contrib/setup-bazel@0.8.5
+        env:
+          USE_BAZEL_VERSION: 6.5.0
         with:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
@@ -199,6 +203,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
       - uses: bazel-contrib/setup-bazel@0.8.5
+        env:
+          USE_BAZEL_VERSION: 6.5.0
         with:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}


### PR DESCRIPTION
The main change to resolve #15 is to explicitly define the version of Bazel to use. Currently (early 2025), leaving it unspecified made the workflow get Bazel version 8.x at run time, which has behaviors and rule library differences that seem to be incompatible with what Chromobius needs.

In addition, this updates the versions of GHA actions used to the current versions.