### PR TITLE
Fix #21: Add #include <algorithm> to atomic_error.test.cc

### DIFF
--- a/src/chromobius/datatypes/atomic_error.test.cc
+++ b/src/chromobius/datatypes/atomic_error.test.cc
@@ -14,6 +14,7 @@
 
 #include "chromobius/datatypes/atomic_error.h"
 
+#include <algorithm>
 #include <random>
 
 #include "gtest/gtest.h"


### PR DESCRIPTION
Adding `#include <algorithms>` solves the problem of the undefined `sort` function.