### PR TITLE
Fix #25: replace ubuntu-20.04 runner version because it is not available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
     - run: bazel build :all
     - run: bazel test :chromobius_test
   build_clang:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - run: |


### PR DESCRIPTION
GitHub retired the ubuntu-20.04 runners. This updates the `build_clang` job in `ci.yml` to use ubuntu-24.04.