### PR TITLE
Add a .bazelrc with a verbose output configuration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,25 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration for producing verbose output to help debugging. To use this,
+# add option "--config=verbose" after commands "bazel build" or "bazel test".
+common:verbose --announce_rc
+common:verbose --show_progress_rate_limit=1
+common:verbose --auto_output_filter=none
+common:verbose --show_timestamps
+common:verbose --subcommands
+common:verbose --verbose_failures
+
+test:verbose --test_summary=detailed
+test:verbose --test_verbose_timeout_warnings

--- a/.bazelrc
+++ b/.bazelrc
@@ -20,6 +20,5 @@ common:verbose --auto_output_filter=none
 common:verbose --show_timestamps
 common:verbose --subcommands
 common:verbose --verbose_failures
-
 test:verbose --test_summary=detailed
 test:verbose --test_verbose_timeout_warnings


### PR DESCRIPTION
I find it helpful to get more output from Bazel runs when debugging. This adds a verbose option that can be used by giving the option `--config=verbose` to Bazel commands.