### PR TITLE
Update versions of Stim and PyMatching used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ set(SIMD_WIDTH 128)
 include(FetchContent)
 FetchContent_Declare(stim
         GIT_REPOSITORY https://github.com/quantumlib/stim.git
-        GIT_TAG da4594c5ede00a063ec2b84bd830f846b5d097dd)
+        GIT_TAG 1320ad7eac7de34d2e9c70daa44fbc6d84174450) # v1.15.dev0 (what PyMatching 2.2.2 uses)
 FetchContent_GetProperties(stim)
 if(NOT stim_POPULATED)
   FetchContent_Populate(stim)
@@ -52,7 +52,7 @@ endif()
 
 FetchContent_Declare(pymatching
         GIT_REPOSITORY https://github.com/oscarhiggott/pymatching.git
-        GIT_TAG 40dcf8c01273ff7e23a7105d5cdc410ada067001)
+        GIT_TAG 08f4f03fc876bd3e13351b677241fc2e160b8b38) # v2.2.2
 FetchContent_GetProperties(pymatching)
 if(NOT pymatching_POPULATED)
   FetchContent_Populate(pymatching)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,13 +3,13 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "stim",
-    commit = "da4594c5ede00a063ec2b84bd830f846b5d097dd",
+    commit = "1320ad7eac7de34d2e9c70daa44fbc6d84174450",
     remote = "https://github.com/quantumlib/stim.git",
 )
 
 git_repository(
     name = "pymatching",
-    commit = "40dcf8c01273ff7e23a7105d5cdc410ada067001",
+    commit = "08f4f03fc876bd3e13351b677241fc2e160b8b38",
     remote = "https://github.com/oscarhiggott/pymatching.git",
 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # These are development requirements, not install requirements.
 matplotlib ~= 3.5
 numpy
-pymatching ~= 2.0
+pymatching ~= 2.2.2
 pytest
 scipy
 sinter ~= 1.14
-stim ~= 1.14
+stim ~= 1.15.0
 pygltflib

--- a/src/chromobius/decode/decoder.cc
+++ b/src/chromobius/decode/decoder.cc
@@ -48,7 +48,7 @@ Decoder Decoder::from_dem(const stim::DetectorErrorModel &dem, DecoderConfigOpti
     if (result.mobius_dem.count_detectors() < result.node_colors.size() * 2) {
         // Ensure the number of detectors in the mobius dem is exactly correct.
         result.mobius_dem.append_detector_instruction(
-            {}, stim::DemTarget::relative_detector_id(result.node_colors.size() * 2 - 1));
+            {}, stim::DemTarget::relative_detector_id(result.node_colors.size() * 2 - 1), "");
     }
 
     // For each node, pick nearby RGB representatives for holding charge near that node.

--- a/src/chromobius/graph/collect_composite_errors.cc
+++ b/src/chromobius/graph/collect_composite_errors.cc
@@ -393,7 +393,7 @@ void chromobius::collect_composite_errors_and_remnants_into_mobius_dem(
                 // weight of the edge, which corresponds to squaring the probability.
                 p *= p;
             }
-            out_mobius_dem->append_error_instruction(p, composite_error_buffer);
+            out_mobius_dem->append_error_instruction(p, composite_error_buffer, "");
         }
     });
 }

--- a/src/chromobius/graph/collect_nodes.cc
+++ b/src/chromobius/graph/collect_nodes.cc
@@ -63,9 +63,9 @@ static void collect_nodes_from_dem_helper_process_detector_instruction(
             stim::DemTarget d1 = stim::DemTarget::relative_detector_id(n * 2 + 1);
 
             coord_buffer->back() = (double)g0;
-            out_mobius_dem->append_detector_instruction(*coord_buffer, d0);
+            out_mobius_dem->append_detector_instruction(*coord_buffer, d0, "");
             coord_buffer->back() = (double)g1;
-            out_mobius_dem->append_detector_instruction(*coord_buffer, d1);
+            out_mobius_dem->append_detector_instruction(*coord_buffer, d1, "");
         }
     }
 }


### PR DESCRIPTION
This updates the versions of PyMatching and Stim used by Chromobius to the highest versions I could get to work without running into more significant API differences. These versions work with NumPy 2, pass the Chromobius tests (running `chromobius_test`), and only needed minimal code changes in 3 files to add a 3rd parameter to Stim's `append_detector_instruction()`.